### PR TITLE
Remove member addresses listing in operating agreement

### DIFF
--- a/operating-agreement.md
+++ b/operating-agreement.md
@@ -2,7 +2,7 @@
 
 #### A Tennessee Limited Liability Company
 
-**THIS OPERATING AGREEMENT** (the “Agreement”) is made and entered into as of the 7th day of March, 2025 (the "Effective Date"), by and between Destinee Brillian Orr, residing at 205 Pond Rd, Cottontown, TN 37048, USA, Patrick Burch, residing at 205 Walnut Lane Ext, Dyersburg, TN 38024, and Kevin Harmon, residing at 3371 Central Curve Rd, Ripley, TN 38063 each individually referred to as a "Member" and collectively as the "Members."
+**THIS OPERATING AGREEMENT** (the “Agreement”) is made and entered into as of the 7th day of March, 2025 (the "Effective Date"), by and between Destinee Brillian Orr, Patrick Burch, and Kevin Harmon each individually referred to as a "Member" and collectively as the "Members."
 
 **RECITALS**
 


### PR DESCRIPTION
This pull request includes a small change to the `operating-agreement.md` file. The change involves removing the specific addresses of the members listed in the operating agreement.